### PR TITLE
new combinator: `appP`

### DIFF
--- a/lib/combinators.js
+++ b/lib/combinators.js
@@ -257,6 +257,9 @@ function appP(p) {
 }
 
 function app(f) {
+    /*
+    (a -> ... -> z) -> Parser e s (m t) a -> ... -> Parser e s (m t) z
+    */
     var args = _get_args(arguments, 1);
     return appP.apply(null, [pure(f)].concat(args));
 }

--- a/lib/combinators.js
+++ b/lib/combinators.js
@@ -241,14 +241,24 @@ function seq() {
     return new Parser(f);
 }
 
-function app(f) {
+function appP(p) {
+    /*
+    Parser e s (m t) (a -> ... -> z) -> Parser e s (m t) a -> ... -> Parser e s (m t) z
+    */
     var parsers = _get_args(arguments, 1);
-    checkFunction('app', f);
-    parsers.map(checkParser.bind(null, 'app')); // can I use `forEach` here as well?
-    function g(args) {
-        return f.apply(undefined, args);
-    }
-    return fmap(g, seq.apply(undefined, parsers));
+    checkParser('appP', p);
+    parsers.map(checkParser.bind(null, 'appP'));
+    return bind(p, function(f) {
+        function g(args) {
+            return f.apply(undefined, args);
+        }
+        return fmap(g, seq.apply(undefined, parsers));
+    });
+}
+
+function app(f) {
+    var args = _get_args(arguments, 1);
+    return appP.apply(null, [pure(f)].concat(args));
 }
 
 function _first(x, _) {
@@ -516,6 +526,7 @@ module.exports = {
     'many1'      : many1,
     'seq'        : seq,
     'app'        : app,
+    'appP'       : appP,
     'optional'   : optional,
     'seq2L'      : seq2L,
     'seq2R'      : seq2R,

--- a/test/combinators.js
+++ b/test/combinators.js
@@ -295,6 +295,18 @@ module('combinators', function() {
         deepEqual(v3, M.zero);
     });
     
+    test("AppP -- type error", function() {
+        try {
+            var parser = C.appP(function() {}, iz1.item);
+            deepEqual(true, false);
+        } catch(e) {
+            var obj = JSON.parse(e.message);
+            deepEqual(obj.message, 'type error');
+            deepEqual(obj.function, 'appP');
+            deepEqual(obj.expected, 'Parser');
+        }
+    });
+    
     test("Optional", function() {
         var parser = C.optional(iz1.literal(3), 'blargh'),
             v1 = parser.parse([1,2,3], 'hi'),

--- a/test/combinators.js
+++ b/test/combinators.js
@@ -296,14 +296,18 @@ module('combinators', function() {
     });
     
     test("AppP -- type error", function() {
+        var autoFail = false;
         try {
             var parser = C.appP(function() {}, iz1.item);
-            deepEqual(true, false);
+            autoFail = true;
         } catch(e) {
             var obj = JSON.parse(e.message);
             deepEqual(obj.message, 'type error');
             deepEqual(obj.function, 'appP');
             deepEqual(obj.expected, 'Parser');
+        }
+        if (autoFail) {
+            deepEqual(true, 'failed to notice type error');
         }
     });
     

--- a/test/combinators.js
+++ b/test/combinators.js
@@ -282,6 +282,19 @@ module('combinators', function() {
         deepEqual(v3, M.zero);
     });
     
+    test("AppP", function() {
+        var parser = C.appP(C.pure(function(a,b,c) {return [a,b,c];}),
+                            iz1.item,
+                            iz1.satisfy(function(x) {return x > 2;}),
+                            iz1.item);
+        var v1 = parser.parse([1,2,3,4,5], 'hi'),
+            v2 = parser.parse([5,6,7,8,9], 'bye'),
+            v3 = parser.parse([5,6], 'goodbye');
+        deepEqual(v1, M.zero);
+        deepEqual(v2, good([8,9], 'bye', [5,6,7]));
+        deepEqual(v3, M.zero);
+    });
+    
     test("Optional", function() {
         var parser = C.optional(iz1.literal(3), 'blargh'),
             v1 = parser.parse([1,2,3], 'hi'),


### PR DESCRIPTION
`appP` is similar to `app`, however, the first argument is `Parser e s (m t) (a -> ... -> z)`, instead of a pure function `(a -> ... -> z)`.  Thus, `appP` is more general than `app`, because the function does not need to be pure.

considerations:

 - [x] existing tests pass
 - [x] `grunt --force` doesn't find anything new
 - [x] write new tests for `appP` which all pass